### PR TITLE
removal of DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+*.DS_Store


### PR DESCRIPTION
This is a stimple git repository update. this will remove the .DS_Store
from being uploaded, as this isnt required within the repo. To do this i
have added it to the gitinore file