### PR TITLE
fix: pr still not failing on error

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -46,7 +46,7 @@ jobs:
       - id: terraform_plan
         name: Run Terraform plan on infra/EKS
         run: terraform -chdir="infra/EKS" plan -no-color -refresh=true || true
-        continue-on-error: true
+        continue-on-error: false
 
       - name: Comment Output onto Pull Request
         uses: actions/github-script@v5
@@ -92,7 +92,3 @@ jobs:
                   repo: context.repo.repo,
                   body: output
                 })
-      
-      - name: Terraform Plan Status
-        if: steps.terraform_plan.outcome == 'failure'
-        run: exit 1


### PR DESCRIPTION
workflow still not showing as failed when plan exit with status 1
have set conntinue-on-error to false this will exit the workflow on the
error but will not print the output to the pr