### PR TITLE
Feat: update database name

### DIFF
--- a/infra/EKS/database.tf
+++ b/infra/EKS/database.tf
@@ -6,7 +6,7 @@ resource "aws_db_instance" "cycling-db" {
   engine                              = "postgres"
   engine_version                      = "13.4"
   instance_class                      = "db.t3.micro"
-  name                                = "cycling_db"
+  db_name                                = "cycling_db"
   username                            = var.db_username
   password                            = var.db_password
   skip_final_snapshot                 = true


### PR DESCRIPTION
Warning: Argument is deprecated

  with aws_db_instance.cycling-db,
  on database.tf line 9, in resource "aws_db_instance" "cycling-db":
   9:   name                                = "cycling_db"

Use db_name instead

using new parameter