### PR TITLE
fix: build fail fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ RUN addgroup -g 1000 -S appgroup && \
 WORKDIR /app
 
 COPY . . 
-
-COPY .pgpass /home/appuser/
-RUN chown appuser:appgroup /home/appuser/.pgpass
-RUN chmod 0600 /home/appuser/.pgpass
  
 RUN chown -R appuser:appgroup /app
 RUN chown -R appuser:appgroup /go


### PR DESCRIPTION
moving .pgpass file from the dockerfile build, this file is no longer
needed as the db connection uses environment variables instead of this
file